### PR TITLE
Add basic gh-pages build to later publish demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,6 @@
 npm-debug.log
 testem.log
 /typings
-/docs
 
 # e2e
 /e2e/*.js

--- a/angular.json
+++ b/angular.json
@@ -43,6 +43,23 @@
             "serviceWorker": true
           },
           "configurations": {
+            "gh-pages": {
+              "baseHref": "https://vibent.github.io/vibent-ui/",
+              "optimization": true,
+              "outputHashing": "all",
+              "sourceMap": true,
+              "extractCss": true,
+              "namedChunks": false,
+              "aot": true,
+              "extractLicenses": true,
+              "vendorChunk": false,
+              "buildOptimizer": true,
+              "outputPath": "docs",
+              "i18nMissingTranslation": "error",
+              "i18nFile": "src/i18n/messages.en.xlf",
+              "i18nFormat": "xlf",
+              "i18nLocale": "en"
+            },
             "dev": {
               "optimization": true,
               "outputHashing": "all",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "start": "ng serve",
     "test": "ng test --watch=false",
     "build": "cross-env NODE_OPTIONS=--max_old_space_size=8192 webpack",
+    "build-gh-pages": "node --max_old_space_size=5048 ./node_modules/@angular/cli/bin/ng build --configuration=gh-pages",
     "build-dev": "node --max_old_space_size=5048 ./node_modules/@angular/cli/bin/ng build --configuration=dev",
     "build-prod": "ng build --configuration=prod",
     "extract-i18n": "ng xi18n vibent-ui --i18n-format xlf --output-path i18n --i18n-locale xxx && ng run vibent-ui:xliffmerge",

--- a/src/app/modules/components/get-app/get-app.component.html
+++ b/src/app/modules/components/get-app/get-app.component.html
@@ -3,7 +3,7 @@
   <div class="card col-md-8 mx-auto p-4 sky-bg">
     <div class="whats-an-app">
       <div class="text-center">
-        <img class="header-logo-min" src="../assets/icons/vibentmin.png"/>
+        <img class="header-logo-min" src="./assets/icons/vibentmin.png"/>
       </div>
       <div class="title text-center" i18n="@@download-app-store">Download an app in a store? So 2018...</div>
     </div>
@@ -16,7 +16,7 @@
       to home screen".... It's done, you just installed Vibent on your phone. And it's a real application, we
       promise.</p>
     <div class="row justify-content-center">
-      <img class="iphone-gif" src="../assets/gifs/iphone-gif-explanation.gif"/>
+      <img class="iphone-gif" src="./assets/gifs/iphone-gif-explanation.gif"/>
     </div>
   </div>
 </div>

--- a/src/app/modules/components/header/header.component.html
+++ b/src/app/modules/components/header/header.component.html
@@ -1,5 +1,5 @@
 <div class="home-header d-flex flex-column flex-md-row align-items-center p-3 px-md-4 shadow-sm">
-  <img class="header-logo-min my-0" src="../assets/icons/vibentmin.png"/>
+  <img class="header-logo-min my-0" src="./assets/icons/vibentmin.png"/>
   <div class="header-board d-flex flex-wrap my-2 my-md-0 ml-md-2">
     <a class="header-board-item p-2 text-black cursor-pointer" (click)="onHowItWorks()" i18n="@@how-it-works">How it works</a>
     <a class="header-board-item p-2 text-black cursor-pointer" (click)="onAboutUs()" i18n="@@about-us">About us</a>

--- a/src/index.html
+++ b/src/index.html
@@ -22,7 +22,7 @@
 <body>
 <app-root>
   <div class="vibent-loading">
-    <img src="../assets/img/vibentmin.svg" style="display: none"/>
+    <img src="./assets/img/vibentmin.svg" style="display: none"/>
     <svg class="spinner-absolute" viewBox="25 25 50 50">
       <circle class="path" cx="50" cy="50" r="20" fill="none" stroke-width="2" stroke-miterlimit="10"></circle>
     </svg>


### PR DESCRIPTION
Add a new build type called `build-gh-pages` that publishes to the /docs folder so on the gh-pages branch it appears on https://vibent.github.io/vibent-ui/. In the future we can add a mocked data so this can host as a demo. The build is mostly a copy of dev build for now, with an added baseHref that works for GitHub Pages.