### PR TITLE
Add survey bubble mock + mock data provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,10 @@ To update gh-pages, do:
 ```bash
 git checkout main
 git pull
+git branch -f gh-pages
 git checkout gh-pages
-git merge main
-rm -r docs
 npm run build-gh-pages
 git add docs
 git commit -m "Publish new version of docs"
-git push
+git push -f
 ```

--- a/angular.json
+++ b/angular.json
@@ -48,6 +48,10 @@
                 {
                   "replace": "src/app/core/http/http.service.ts",
                   "with": "src/app/core/http/http.service.mock.ts"
+                },
+                {
+                  "replace": "src/app/core/services/bubbles-services/survey/http/survey-http.service.ts",
+                  "with": "src/app/core/services/bubbles-services/survey/http/survey-http.service.mock.ts"
                 }
               ],
               "optimization": true,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -21,6 +21,7 @@ import { AngularFireAuthModule } from '@angular/fire/auth';
 import { AngularFireMessagingModule } from '@angular/fire/messaging';
 import { AngularFireModule } from '@angular/fire';
 import { environment } from '../environments/environment';
+import { MockData } from './shared/global/mock-data';
 
 /**
  * This module is the primary module of Vibent
@@ -54,7 +55,7 @@ import { environment } from '../environments/environment';
   declarations: [
     AppComponent
   ],
-  providers: [FirebaseMessagingService],
+  providers: [FirebaseMessagingService, MockData],
   bootstrap: [AppComponent],
   entryComponents: [
     LoadingPageComponent

--- a/src/app/core/http/http.service.mock.ts
+++ b/src/app/core/http/http.service.mock.ts
@@ -1,71 +1,25 @@
-import { Injectable } from '@angular/core';
-import { Event } from '../../shared/models/event';
-import { Observable, of } from 'rxjs';
-import { Email, PasswordReset, User } from '../../shared/models/user';
-import { EventParticipant, EventParticipantAnswer } from '../../shared/models/event-participant';
-import { MailInvite } from '../../shared/models/mailInvite';
 import { DistributionList, DistributionListRequest } from '../../shared/models/distribution-list';
+import { Email, PasswordReset, User } from '../../shared/models/user';
+import { Event } from '../../shared/models/event';
+import { EventParticipant } from '../../shared/models/event-participant';
+import { Injectable } from '@angular/core';
+import { MailInvite } from '../../shared/models/mailInvite';
+import { MockData } from '../../shared/global/mock-data';
+import { Observable, of } from 'rxjs';
 
 @Injectable()
 export class HttpService {
 
-  private users: User[] = [
-    {
-      ref: "user1",
-      email: "email@no.domain.com",
-      firstName: "John",
-      lastName: "Smith",
-      phoneNumber: 12085434383,
-      memberships: [],
-      participations: [],
-      membershipRequests: [],
-      socialCredentials: {},
-      profilePicLocation: "assets/img/vibent-icon-72.png"
-    }
-  ]
-
-  private events: Event[] = [{
-    title: "Cool party at the beach",
-    ref: "event1",
-    creatorRef: this.users[0].ref,
-    description: "This is an event for the beach",
-    endDate: new Date(),
-    startDate: new Date().toISOString(),
-    groupRef: "group1",
-    participationRefs: [
-      {
-        id: 4,
-        userRef: "user1",
-        eventRef: "event1",
-        isVisible: true,
-        answer: EventParticipantAnswer.YES
-      }
-    ],
-
-    alimentationBubbles: [],
-    checkboxBubbles: [],
-    freeBubbles: [],
-    locationBubbles: [],
-    planningBubbles: [],
-    surveyBubbles: [],
-    travelBubbles: []
-  }];
-
-
-
-
-  constructor() { }
-
-
+  constructor(private mockData: MockData) { }
 
   /*** Events ***/
 
   public getEvents(): Observable<Event[]> {
-    return of(this.events);
+    return of(this.mockData.events);
   }
 
   public getEvent(eventRef: string): Observable<Event> {
-    const event = this.events.find(e => e.ref == eventRef);
+    const event = this.mockData.events.find(e => e.ref == eventRef);
     return of(event);
   }
 
@@ -102,12 +56,12 @@ export class HttpService {
   /*** User ***/
 
   public getMe(): Observable<User> {
-    const user = this.users[0];
+    const user = this.mockData.users[0];
     return of(user);
   }
 
   public getUser(userRef: string): Observable<User> {
-    const user = this.users.find(e => e.ref == userRef);
+    const user = this.mockData.users.find(e => e.ref == userRef);
     return of(user);
   }
 
@@ -117,7 +71,7 @@ export class HttpService {
 
   /*** Participation ***/
   public getEventParticipations(eventRef: string): Observable<EventParticipant[]> {
-    const event = this.events.find(e => e.ref == eventRef);
+    const event = this.mockData.events.find(e => e.ref == eventRef);
     return of(event.participationRefs);
   }
 
@@ -166,7 +120,7 @@ export class HttpService {
   }
 
   public loginPhone(loginRequest): Observable<any> {
-    return of("hello");
+    return of({});
   }
 
   public socialLogin(loginRequest): Observable<any> {

--- a/src/app/core/services/bubbles-services/survey/http/survey-http.service.mock.ts
+++ b/src/app/core/services/bubbles-services/survey/http/survey-http.service.mock.ts
@@ -1,0 +1,43 @@
+import { Injectable } from '@angular/core';
+import { MockData } from '../../../../../shared/global/mock-data';
+import { of } from 'rxjs';
+import { SurveyAnswer, SurveyBubble, SurveyOption } from '../../../../../shared/models/bubbles/SurveyBubble';
+
+@Injectable()
+export class SurveyHttpService {
+
+  constructor(private mockData: MockData) { }
+
+  getBubble(bubbleId: number) {
+    return of(this.mockData.surveysBubbles.find(b => b.id == bubbleId))
+  }
+
+  updateBubble(bubble: SurveyBubble) {
+    return of(bubble);
+  }
+
+  deleteBubble(bubble: SurveyBubble) {
+    return of({});
+  }
+
+  createOption(option: SurveyOption) {
+    return of(option);
+  }
+
+  deleteOption(option: SurveyOption) {
+    return of({});
+  }
+
+  createAnswer(answer: SurveyAnswer) {
+    return of(answer);
+  }
+
+  deleteAnswerOfOption(option: SurveyOption) {
+    return of({});
+  }
+
+  deleteAnswer(answer: SurveyAnswer) {
+    return of({});
+  }
+
+}

--- a/src/app/shared/global/mock-data.ts
+++ b/src/app/shared/global/mock-data.ts
@@ -21,10 +21,18 @@ export class MockData {
             lastName: "Smith",
             phoneNumber: 12085434383,
             memberships: [],
-            participations: [],
+            participations: [
+                {
+                    id: 1,
+                    userRef: this.userRef,
+                    eventRef: this.eventRef,
+                    isVisible: true,
+                    answer: EventParticipantAnswer.YES,
+                }
+            ],
             membershipRequests: [],
             socialCredentials: {},
-            profilePicLocation: "assets/img/vibent-icon-72.png"
+            profilePicLocation: "assets/img/vibent-icon-72.png",
         }
     ]
 

--- a/src/app/shared/global/mock-data.ts
+++ b/src/app/shared/global/mock-data.ts
@@ -1,0 +1,86 @@
+import { BubbleType } from 'app/shared/models/bubbles/IBubble';
+import { Event } from '../../shared/models/event';
+import { EventParticipantAnswer } from '../../shared/models/event-participant';
+import { Injectable } from '@angular/core';
+import { SurveyBubble } from '../../shared/models/bubbles/SurveyBubble';
+import { User } from '../../shared/models/user';
+
+
+
+@Injectable()
+export class MockData {
+
+    private userRef = "3861f9fa-ac82-487c-a923-6b60230c0c2a";
+    private eventRef = "736c2838-5d79-43a6-9691-47a67b7f5e74";
+
+    public users: User[] = [
+        {
+            ref: this.userRef,
+            email: "john.smith@no.domain.com",
+            firstName: "John",
+            lastName: "Smith",
+            phoneNumber: 12085434383,
+            memberships: [],
+            participations: [],
+            membershipRequests: [],
+            socialCredentials: {},
+            profilePicLocation: "assets/img/vibent-icon-72.png"
+        }
+    ]
+
+    public surveysBubbles: SurveyBubble[] = [
+        {
+            id: 1,
+            creatorRef: this.userRef,
+            eventRef: this.eventRef,
+            type: BubbleType.SurveyBubble,
+            options: [
+                {
+                    bubbleId: 1,
+                    answers: [
+                        {
+                            id: 1,
+                            optionId: 1,
+                            userRef: this.userRef,
+                        }
+                    ],
+                    content: "None",
+                    id: 2,
+                    userRef: this.userRef,
+                }
+            ],
+            title: "Dietary restrictions?",
+            answerCount: 1
+        }
+    ]
+
+    public events: Event[] = [
+        {
+            title: "Cool party at the beach",
+            ref: this.eventRef,
+            creatorRef: this.userRef,
+            description: "This is an event for the beach",
+            endDate: new Date(),
+            startDate: new Date().toISOString(),
+            groupRef: "group1",
+            participationRefs: [
+                {
+                    id: 4,
+                    userRef: this.userRef,
+                    eventRef: this.eventRef,
+                    isVisible: true,
+                    answer: EventParticipantAnswer.YES
+                }
+            ],
+
+            alimentationBubbles: [],
+            checkboxBubbles: [],
+            freeBubbles: [],
+            locationBubbles: [],
+            planningBubbles: [],
+            surveyBubbles: this.surveysBubbles,
+            travelBubbles: []
+        }
+    ];
+
+}


### PR DESCRIPTION
Create a `mock-data` provider that can be a central data store for mock data, making relationships between objects easier. I know it's not the cleanest solution, but it should allow us to quickly get a demo of everything in Vibent.
Also add Survey Bubble example using the new data. Again, we will need to add more answers etc.

[Demo](https://vibent.github.io/vibent-ui)